### PR TITLE
Remove is_regex guard

### DIFF
--- a/lib/inflex/pluralize.ex
+++ b/lib/inflex/pluralize.ex
@@ -96,7 +96,7 @@ defmodule Inflex.Pluralize do
         Enum.find(set, fn({ reg, _ }) -> Regex.match?(reg, word) end)
       end
 
-      defp replace({regex, replacement}, word) do
+      defp replace({regex, replacement}, word) when is_record(regex, Regex) do
         Regex.replace(regex, word, replacement)
       end
       defp replace(_, word), do: word


### PR DESCRIPTION
These are apparently going away.  This changes behaviour slightly, but
it will still raise a FunctionClauseError since that's what
Regex.replace raises if you pass it a non-regex....

@josevalim I'd love feedback on this if you had a sec...
