### PR TITLE
Bump version to 0.2.4 after commit that adds 0.14.2 compatibility

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule Inflex.Mixfile do
   def project do
     [
       app: :inflex,
-      version: "0.2.3",
+      version: "0.2.4",
       elixir: ">= 0.14.0",
       deps: [],
       package: [


### PR DESCRIPTION
This just bumps the version to 0.2.4. The 0.2.3 version on mix.pm does not have the commit b9053a5319731adabc4ab625be48ff7fa9ca1d0c that seems to be required for inflex to compile with elixir 0.14.2
