### PR TITLE
Camelize should be idempotent

### DIFF
--- a/lib/inflex/camelize.ex
+++ b/lib/inflex/camelize.ex
@@ -5,9 +5,11 @@ defmodule Inflex.Camelize do
       import unquote __MODULE__
 
       def camelize(word, option\\:upper) do
-        Regex.split(~r/(?:^|[-_])/, to_string(word)) |>
-          camelize_list(option) |>
-          Enum.join
+        case Regex.split(~r/(?:^|[-_])/, to_string(word)) do
+          [ word ] -> word
+          words    -> words |> camelize_list(option)
+                            |> Enum.join
+        end
       end
 
       defp camelize_list([], :upper), do: []

--- a/test/inflex_test.exs
+++ b/test/inflex_test.exs
@@ -46,12 +46,14 @@ defmodule InflexTest do
 
   test :camelize_upper do
     assert "UpperCamelCase" == camelize("upper_camel_case")
+    assert "UpperCamelCase" == camelize("UpperCamelCase")
     refute "UpperCamelCase" == camelize("upper_camel_case", :lower)
   end
 
   test :camelize_lower do
     assert "lowerCamelCase" == camelize("lower_camel_case", :lower)
     assert "lowerCamelCase" == camelize("Lower_camel_case", :lower)
+    assert "lowerCamelCase" == camelize("lowerCamelCase", :lower)
     refute "lowerCamelCase" == camelize("lower_camel_case")
   end
 


### PR DESCRIPTION
If string is already camelized, it should not be destructed by `Inflex.camelize` like this:

```elixir
Inflex.camelize("UpperCamelCase")  #=> Uppercamelcase
```