### PR TITLE
Convert atoms to string when passed to Inflex

### DIFF
--- a/lib/inflex/pluralize.ex
+++ b/lib/inflex/pluralize.ex
@@ -104,9 +104,14 @@ defmodule Inflex.Pluralize do
         { ~r/$/i, "s" },
         ]
 
-
+      def singularize(word) when is_atom(word) do
+        find_match(@singular, to_string(word))
+      end
       def singularize(word), do: find_match(@singular, word)
 
+      def pluralize(word) when is_atom(word) do
+        find_match(@plural, to_string(word))
+      end
       def pluralize(word), do: find_match(@plural, word)
 
       def inflect(word, 1), do: singularize word

--- a/test/inflex_test.exs
+++ b/test/inflex_test.exs
@@ -31,6 +31,8 @@ defmodule InflexTest do
     assert "die" == singularize("dice")
     assert "phenomenon" == singularize("phenomena")
     assert "license" == singularize("licenses")
+
+    assert "bus" == singularize(:buses)
   end
 
   test :pluralize do
@@ -58,6 +60,8 @@ defmodule InflexTest do
     assert "feet" == pluralize("foot")
     assert "dice" == pluralize("die")
     assert "phenomena" == pluralize("phenomenon")
+
+    assert "buses" == pluralize(:bus)
   end
 
   test :special_case_nouns_ending_in_o do


### PR DESCRIPTION
Adds a guard clause to `singularize/1` and `plurualize/1` to convert
atoms to strings when the argument is a string.