### PR TITLE
Restructure lib to prefer delegation over copying functions with `use`

### DIFF
--- a/lib/inflex.ex
+++ b/lib/inflex.ex
@@ -1,15 +1,6 @@
 defmodule Inflex do
-  use Inflex.Camelize
-  use Inflex.Pluralize
-  use Inflex.Parameterize
-  use Inflex.Underscore
-
-  defmacro __using__([]) do
-    quote do
-      use Inflex.Camelize
-      use Inflex.Pluralize
-      use Inflex.Parameterize
-      use Inflex.Underscore
-    end
-  end
+  defdelegate [camelize(word), camelize(word, option)], to: Inflex.Camelize
+  defdelegate [singularize(word), pluralize(word), inflect(word, count)], to: Inflex.Pluralize
+  defdelegate [parameterize(word), parameterize(word, option)], to: Inflex.Parameterize
+  defdelegate underscore(word), to: Inflex.Underscore
 end

--- a/lib/inflex.ex
+++ b/lib/inflex.ex
@@ -1,6 +1,79 @@
 defmodule Inflex do
+  @doc """
+  Camelizes or pascalizes strings and atoms.
+
+  ## Examples
+
+      iex> Inflex.camelize(:upper_camel_case)
+      "UpperCamelCase"
+
+      iex> Inflex.camelize("pascal-case", :lower)
+      "pascalCase"
+  """
   defdelegate [camelize(word), camelize(word, option)], to: Inflex.Camelize
-  defdelegate [singularize(word), pluralize(word), inflect(word, count)], to: Inflex.Pluralize
+
+  @doc """
+  Singularize a word.
+
+  ## Examples
+
+      iex> Inflex.singularize("dogs")
+      "dog"
+
+      iex> Inflex.singularize("people")
+      "person"
+  """
+  defdelegate singularize(word), to: Inflex.Pluralize
+
+  @doc """
+  Pluralize a word.
+
+  ## Examples
+
+      iex> Inflex.pluralize("dog")
+      "dogs"
+
+      iex> Inflex.pluralize("person")
+      "people"
+  """
+  defdelegate pluralize(word), to: Inflex.Pluralize
+
+  @doc """
+  Inflect on the plurality of a word given some count.
+
+  ## Examples
+
+      iex> Inflex.inflect("child", 1)
+      "child"
+
+      iex> Inflex.inflect("child", 2)
+      "children"
+  """
+  defdelegate inflect(word, count), to: Inflex.Pluralize
+
+  @doc """
+  Parameterize a string given some separator.
+
+  ## Examples
+
+      iex> Inflex.parameterize("String for parameter")
+      "string-for-parameter"
+
+      iex> Inflex.parameterize("String with underscore", "_")
+      "string_with_underscore"
+  """
   defdelegate [parameterize(word), parameterize(word, option)], to: Inflex.Parameterize
+
+  @doc """
+  Underscore and lowercase a string.
+
+  ## Examples
+
+      iex> Inflex.underscore("UpperCamelCase")
+      "upper_camel_case"
+
+      iex> Inflex.underscore(:pascalCase)
+      "pascal_case"
+  """
   defdelegate underscore(word), to: Inflex.Underscore
 end

--- a/lib/inflex/camelize.ex
+++ b/lib/inflex/camelize.ex
@@ -1,26 +1,19 @@
 defmodule Inflex.Camelize do
-
-  defmacro __using__([]) do
-    quote do
-      import unquote __MODULE__
-
-      def camelize(word, option\\:upper) do
-        case Regex.split(~r/(?:^|[-_])|(?=[A-Z])/, to_string(word)) do
-          words -> words |> camelize_list(option)
-                         |> Enum.join
-        end
-      end
-
-      defp camelize_list([], :upper), do: []
-      defp camelize_list([h|tail], :lower) do
-        [lowercase(h)] ++ camelize_list(tail, :upper)
-      end
-      defp camelize_list([h|tail], :upper) do
-        [capitalize(h)] ++ camelize_list(tail, :upper)
-      end
-
-      def capitalize(word), do: String.capitalize(word)
-      def lowercase(word), do: String.downcase(word)
+  def camelize(word, option\\:upper) do
+    case Regex.split(~r/(?:^|[-_])|(?=[A-Z])/, to_string(word)) do
+      words -> words |> camelize_list(option)
+                     |> Enum.join
     end
   end
+
+  defp camelize_list([], :upper), do: []
+  defp camelize_list([h|tail], :lower) do
+    [lowercase(h)] ++ camelize_list(tail, :upper)
+  end
+  defp camelize_list([h|tail], :upper) do
+    [capitalize(h)] ++ camelize_list(tail, :upper)
+  end
+
+  def capitalize(word), do: String.capitalize(word)
+  def lowercase(word), do: String.downcase(word)
 end

--- a/lib/inflex/camelize.ex
+++ b/lib/inflex/camelize.ex
@@ -1,4 +1,6 @@
 defmodule Inflex.Camelize do
+  @moduledoc false
+
   def camelize(word, option\\:upper) do
     case Regex.split(~r/(?:^|[-_])|(?=[A-Z])/, to_string(word)) do
       words -> words |> camelize_list(option)

--- a/lib/inflex/parameterize.ex
+++ b/lib/inflex/parameterize.ex
@@ -1,4 +1,6 @@
 defmodule Inflex.Parameterize do
+  @moduledoc false
+
   def parameterize(word, option\\"-") do
     Regex.split(~r/\s|\%20/, word) |>
     Enum.join(option) |>

--- a/lib/inflex/parameterize.ex
+++ b/lib/inflex/parameterize.ex
@@ -1,15 +1,7 @@
 defmodule Inflex.Parameterize do
-
-  defmacro __using__([]) do
-    quote do
-      import unquote __MODULE__
-
-      def parameterize(word, option\\"-") do
-        Regex.split(~r/\s|\%20/, word) |>
-        Enum.join(option) |>
-        String.downcase
-      end
-
-    end
+  def parameterize(word, option\\"-") do
+    Regex.split(~r/\s|\%20/, word) |>
+    Enum.join(option) |>
+    String.downcase
   end
 end

--- a/lib/inflex/pluralize.ex
+++ b/lib/inflex/pluralize.ex
@@ -1,144 +1,138 @@
 defmodule Inflex.Pluralize do
+  @default true
 
-  defmacro __using__([]) do
-    quote do
-      @default true
+  @uncountable  [
+    "equipment",
+    "fish",
+    "information",
+    "jeans",
+    "money",
+    "police",
+    "rice",
+    "series",
+    "sheep",
+    "species"
+    ]
 
-      @uncountable  [
-        "equipment",
-        "fish",
-        "information",
-        "jeans",
-        "money",
-        "police",
-        "rice",
-        "series",
-        "sheep",
-        "species"
-        ]
+  @irregular [
+    { ~r/people/i, "person" },
+    { ~r/^(zombie)s$/i, "\\1" },
+    { ~r/geese/i, "goose" },
+    { ~r/criteria/i, "criterion" },
+    { ~r/radii/i, "radius" },
+    { ~r/^men/i, "man"},
+    { ~r/^echoes/i, "echo"},
+    { ~r/^heroes/i, "hero"},
+    { ~r/^potatoes/i, "potato"},
+    { ~r/^tomatoes/i, "tomato"},
+    { ~r/^teeth/i, "tooth"},
+    { ~r/^lice$/i, "louse"},
+    { ~r/^quanta/i, "quantum"},
+    { ~r/^dice/i, "die"},
+    { ~r/^feet/i, "foot"},
+    { ~r/^phenomena/i, "phenomenon"},
+    ]
 
-      @irregular [
-        { ~r/people/i, "person" },
-        { ~r/^(zombie)s$/i, "\\1" },
-        { ~r/geese/i, "goose" },
-        { ~r/criteria/i, "criterion" },
-        { ~r/radii/i, "radius" },
-        { ~r/^men/i, "man"},
-        { ~r/^echoes/i, "echo"},
-        { ~r/^heroes/i, "hero"},
-        { ~r/^potatoes/i, "potato"},
-        { ~r/^tomatoes/i, "tomato"},
-        { ~r/^teeth/i, "tooth"},
-        { ~r/^lice$/i, "louse"},
-        { ~r/^quanta/i, "quantum"},
-        { ~r/^dice/i, "die"},
-        { ~r/^feet/i, "foot"},
-        { ~r/^phenomena/i, "phenomenon"},
-        ]
+  @plural_irregular [
+    { ~r/person/i, "people" },
+    { ~r/^zombies$/i, "zombie" },
+    { ~r/goose/i, "geese" },
+    { ~r/criterion/i, "criteria" },
+    { ~r/radius/i, "radii" },
+    { ~r/man/i, "men"},
+    { ~r/^men/i, "men"},
+    { ~r/^women/i, "women"},
+    { ~r/^echo/i, "echoes"},
+    { ~r/^hero/i, "heroes"},
+    { ~r/^potato/i, "potatoes"},
+    { ~r/^tomato/i, "tomatoes"},
+    { ~r/^tooth/i, "teeth"},
+    { ~r/^louse/i, "lice"},
+    { ~r/^quantum/i, "quanta"},
+    { ~r/^die/i, "dice"},
+    { ~r/^foot/i, "feet"},
+    { ~r/^phenomenon/i, "phenomena"},
+    ]
 
-      @plural_irregular [
-        { ~r/person/i, "people" },
-        { ~r/^zombies$/i, "zombie" },
-        { ~r/goose/i, "geese" },
-        { ~r/criterion/i, "criteria" },
-        { ~r/radius/i, "radii" },
-        { ~r/man/i, "men"},
-        { ~r/^men/i, "men"},
-        { ~r/^women/i, "women"},
-        { ~r/^echo/i, "echoes"},
-        { ~r/^hero/i, "heroes"},
-        { ~r/^potato/i, "potatoes"},
-        { ~r/^tomato/i, "tomatoes"},
-        { ~r/^tooth/i, "teeth"},
-        { ~r/^louse/i, "lice"},
-        { ~r/^quantum/i, "quanta"},
-        { ~r/^die/i, "dice"},
-        { ~r/^foot/i, "feet"},
-        { ~r/^phenomenon/i, "phenomena"},
-        ]
+  @singular @irregular ++ [
+    { ~r/(child)ren/i, "\\1" },
+    { ~r/(wo|sea)men$/i, "\\1man" },
+    { ~r/(m|l)ice$/i, "\\1ouse" },
+    { ~r/(bus)(es)?$/i, "\\1" },
+    { ~r/(ss)$/i, "\\1" },
+    { ~r/(database)s$/i, "\\1" },
+    { ~r/(n)ews$/i, "\\1ews" },
+    { ~r/([ti])a$/i, "\1um" },
+    { ~r/((a)naly|(b)a|(d)iagno|(p)arenthe|(p)rogno|(s)ynop|(t)he)(sis|ses)$/i, "\\1sis" },
+    { ~r/(analy)(sis|ses)$/i, "\\1sis" },
+    { ~r/(octop|vir)i$/i, "\\1us" },
+    { ~r/([^f])ves$/i, "\\1fe" },
+    { ~r/(hive)s$/i, "\\1" },
+    { ~r/(tive)s$/i, '\\1' },
+    { ~r/([lr])ves$/i, "\\1f" },
+    { ~r/([^aeiouy]|qu)ies$/i, "\\1y" },
+    { ~r/(m)ovies$/i, "\\1ovie" },
+    { ~r/(x|ch|ss|sh)es$/i, "\\1" },
+    { ~r/(shoe)s$/i, "\\1" },
+    { ~r/(o)es$/i, "\\1" },
+    { ~r/s$/i, "" },
+    ]
 
-      @singular @irregular ++ [
-        { ~r/(child)ren/i, "\\1" },
-        { ~r/(wo|sea)men$/i, "\\1man" },
-        { ~r/(m|l)ice$/i, "\\1ouse" },
-        { ~r/(bus)(es)?$/i, "\\1" },
-        { ~r/(ss)$/i, "\\1" },
-        { ~r/(database)s$/i, "\\1" },
-        { ~r/(n)ews$/i, "\\1ews" },
-        { ~r/([ti])a$/i, "\1um" },
-        { ~r/((a)naly|(b)a|(d)iagno|(p)arenthe|(p)rogno|(s)ynop|(t)he)(sis|ses)$/i, "\\1sis" },
-        { ~r/(analy)(sis|ses)$/i, "\\1sis" },
-        { ~r/(octop|vir)i$/i, "\\1us" },
-        { ~r/([^f])ves$/i, "\\1fe" },
-        { ~r/(hive)s$/i, "\\1" },
-        { ~r/(tive)s$/i, '\\1' },
-        { ~r/([lr])ves$/i, "\\1f" },
-        { ~r/([^aeiouy]|qu)ies$/i, "\\1y" },
-        { ~r/(m)ovies$/i, "\\1ovie" },
-        { ~r/(x|ch|ss|sh)es$/i, "\\1" },
-        { ~r/(shoe)s$/i, "\\1" },
-        { ~r/(o)es$/i, "\\1" },
-        { ~r/s$/i, "" },
-        ]
+  @plural @plural_irregular ++ [
+    { ~r/(child)$/i, "\\1ren" },
+    { ~r/(wo)?man$/i, "\\1men" },
+    { ~r/(m|l)ouse/i, "\\1ice" },
+    { ~r/(database)s$/i, "\\1" },
+    { ~r/(quiz)$/i, "\\1zes" },
+    { ~r/^(ox)$/i, "\\1en" },
+    { ~r/(matr|vert|ind)ix|ex$/i, "\\1ices" },
+    { ~r/(x|ch|ss|sh)$/i, "\\1es" },
+    { ~r/([^aeiouy]|qu)y$/i, "\\1ies" },
+    { ~r/(hive)$/i, "\\1s" },
+    { ~r/(?:([^f])fe|([lr])f)$/i, "\\1\\1ves" },
+    { ~r/sis$/i, "ses" },
+    { ~r/([ti])um$/i, "\\1a" },
+    { ~r/(buffal|tomat)o$/i, "\\1oes" },
+    { ~r/(octop|vir)us$/i, "\\1i" },
+    { ~r/(alias|status)$/i, "\\1es" },
+    { ~r/(ax|test)is$/i, "\\1es" },
+    { ~r/(bus)$/i, "\\1es" },
+    { ~r/s$/i, "s" },
+    { ~r/$/i, "s" },
+    ]
 
-      @plural @plural_irregular ++ [
-        { ~r/(child)$/i, "\\1ren" },
-        { ~r/(wo)?man$/i, "\\1men" },
-        { ~r/(m|l)ouse/i, "\\1ice" },
-        { ~r/(database)s$/i, "\\1" },
-        { ~r/(quiz)$/i, "\\1zes" },
-        { ~r/^(ox)$/i, "\\1en" },
-        { ~r/(matr|vert|ind)ix|ex$/i, "\\1ices" },
-        { ~r/(x|ch|ss|sh)$/i, "\\1es" },
-        { ~r/([^aeiouy]|qu)y$/i, "\\1ies" },
-        { ~r/(hive)$/i, "\\1s" },
-        { ~r/(?:([^f])fe|([lr])f)$/i, "\\1\\1ves" },
-        { ~r/sis$/i, "ses" },
-        { ~r/([ti])um$/i, "\\1a" },
-        { ~r/(buffal|tomat)o$/i, "\\1oes" },
-        { ~r/(octop|vir)us$/i, "\\1i" },
-        { ~r/(alias|status)$/i, "\\1es" },
-        { ~r/(ax|test)is$/i, "\\1es" },
-        { ~r/(bus)$/i, "\\1es" },
-        { ~r/s$/i, "s" },
-        { ~r/$/i, "s" },
-        ]
+  def singularize(word) when is_atom(word) do
+    find_match(@singular, to_string(word))
+  end
+  def singularize(word), do: find_match(@singular, word)
 
-      def singularize(word) when is_atom(word) do
-        find_match(@singular, to_string(word))
-      end
-      def singularize(word), do: find_match(@singular, word)
+  def pluralize(word) when is_atom(word) do
+    find_match(@plural, to_string(word))
+  end
+  def pluralize(word), do: find_match(@plural, word)
 
-      def pluralize(word) when is_atom(word) do
-        find_match(@plural, to_string(word))
-      end
-      def pluralize(word), do: find_match(@plural, word)
+  def inflect(word, 1), do: singularize word
+  def inflect(word, n) when is_number(n), do: pluralize word
 
-      def inflect(word, 1), do: singularize word
-      def inflect(word, n) when is_number(n), do: pluralize word
-
-      defp find_match(set, word) do
-        cond do
-          uncountable?(word) -> word
-          @default -> replace_match(set, word)
-        end
-      end
-
-      defp replace_match(set, word) do
-        find_in_set(set, word) |> replace(word)
-      end
-
-      defp find_in_set(set, word) do
-        Enum.find(set, fn({ reg, _ }) -> Regex.match?(reg, word) end)
-      end
-
-      defp replace({regex, replacement}, word) do
-        Regex.replace(regex, word, replacement)
-      end
-      defp replace(_, word), do: word
-
-      defp uncountable?(word), do: Enum.member?(@uncountable, word)
+  defp find_match(set, word) do
+    cond do
+      uncountable?(word) -> word
+      @default -> replace_match(set, word)
     end
   end
 
+  defp replace_match(set, word) do
+    find_in_set(set, word) |> replace(word)
+  end
+
+  defp find_in_set(set, word) do
+    Enum.find(set, fn({ reg, _ }) -> Regex.match?(reg, word) end)
+  end
+
+  defp replace({regex, replacement}, word) do
+    Regex.replace(regex, word, replacement)
+  end
+  defp replace(_, word), do: word
+
+  defp uncountable?(word), do: Enum.member?(@uncountable, word)
 end

--- a/lib/inflex/pluralize.ex
+++ b/lib/inflex/pluralize.ex
@@ -1,4 +1,5 @@
 defmodule Inflex.Pluralize do
+  @moduledoc false
   @default true
 
   @uncountable  [

--- a/lib/inflex/underscore.ex
+++ b/lib/inflex/underscore.ex
@@ -1,24 +1,16 @@
 defmodule Inflex.Underscore do
-
-  defmacro __using__([]) do
-    quote do
-      import unquote __MODULE__
-
-      def underscore(atom) when is_atom(atom) do
-        case Atom.to_string(atom) do
-          "Elixir." <> rest -> underscore(rest)
-          word -> underscore(word)
-        end
-      end
-
-      def underscore(word) when is_binary(word) do
-        word
-        |> String.replace(~r/([A-Z]+)([A-Z][a-z])/, "\\1_\\2")
-        |> String.replace(~r/([a-z\d])([A-Z])/, "\\1_\\2")
-        |> String.replace(~r/-/, "_")
-        |> String.downcase
-      end
-
+  def underscore(atom) when is_atom(atom) do
+    case Atom.to_string(atom) do
+      "Elixir." <> rest -> underscore(rest)
+      word -> underscore(word)
     end
+  end
+
+  def underscore(word) when is_binary(word) do
+    word
+    |> String.replace(~r/([A-Z]+)([A-Z][a-z])/, "\\1_\\2")
+    |> String.replace(~r/([a-z\d])([A-Z])/, "\\1_\\2")
+    |> String.replace(~r/-/, "_")
+    |> String.downcase
   end
 end

--- a/lib/inflex/underscore.ex
+++ b/lib/inflex/underscore.ex
@@ -1,4 +1,6 @@
 defmodule Inflex.Underscore do
+  @moduledoc false
+
   def underscore(atom) when is_atom(atom) do
     case Atom.to_string(atom) do
       "Elixir." <> rest -> underscore(rest)

--- a/test/inflex_test.exs
+++ b/test/inflex_test.exs
@@ -1,7 +1,7 @@
 defmodule InflexTest do
   use ExUnit.Case
 
-  use Inflex
+  import Inflex
 
   test :singularize do
     assert "user" == singularize("users")


### PR DESCRIPTION
* Each `use` in effect "copies" function definitions into modules. Per
  #32, it is preferable to use defdelegate to organize functions into
  separate modules.
* Thankfully the only breaking change is an undocumented `use Inflex`
  that is found in the test suite. Thankfully it can easily be changed
  to `import Inflex` to continue passing and follow the recommended use
  in the readme.

TODO
- [x] restructure code to prefer delegation of `use`
- [x] add documentation for functions

This should address #32 and #34 