### PR TITLE
Scope irregular singularization of lice and mice

### DIFF
--- a/lib/inflex/pluralize.ex
+++ b/lib/inflex/pluralize.ex
@@ -57,7 +57,7 @@ defmodule Inflex.Pluralize do
   @singular @irregular ++ [
     { ~r/(child)ren/i, "\\1" },
     { ~r/(wo|sea)men$/i, "\\1man" },
-    { ~r/(m|l)ice$/i, "\\1ouse" },
+    { ~r/^(m|l)ice$/i, "\\1ouse" },
     { ~r/(bus)(es)?$/i, "\\1" },
     { ~r/(ss)$/i, "\\1" },
     { ~r/(database)s$/i, "\\1" },

--- a/test/inflex_test.exs
+++ b/test/inflex_test.exs
@@ -151,6 +151,8 @@ defmodule InflexTest do
     assert "child" == inflect("children", 1)
     assert "people" == inflect("person", 2)
     assert "dogs" == inflect("dog", 3.2)
+    assert "slice" == inflect("slice", 1)
+    assert "accomplice" == inflect("accomplice", 1)
   end
 
 end


### PR DESCRIPTION
This irregular rule is being over-applied to things like

- slice -> slouse
- accomplice -> accomplouse

when run through `singularize` or `inflect` with a `1`.

The irregular singularization is limited to _lice_ and _mice_ as far as
I can tell. That is, there aren't longer or compound words ending in
_lice_ or _mice_ that also have an irregular singular form. Hence, I
believe an appropriate solution is to cap the regex for this rule to the
beginning of the line.