### PR TITLE
Change parameterize to use a regex replacement like that in rails

### DIFF
--- a/lib/inflex/parameterize.ex
+++ b/lib/inflex/parameterize.ex
@@ -4,6 +4,7 @@ defmodule Inflex.Parameterize do
   def parameterize(word, option\\"-") do
     Regex.split(~r/\s|\%20/, word) |>
     Enum.join(option) |>
-    String.downcase
+    String.downcase |>
+    String.replace(~r/[^a-z0-9\-_]+/i, option)
   end
 end

--- a/test/inflex_test.exs
+++ b/test/inflex_test.exs
@@ -111,6 +111,7 @@ defmodule InflexTest do
     assert "elixir-inflex" == parameterize("Elixir Inflex")
     assert "elixir_inflex" == parameterize("elixir inflex", "_")
     assert "elixir-inflex" == parameterize("elixir%20inflex")
+    assert "elixir-inflex" == parameterize("elixir:inflex")
   end
 
   test :underscore do


### PR DESCRIPTION
Hi there!
When I came across this library, I was looking for something more along the lines of the Rails `.parameterize` which replaces more characters than just spaces with the given separator for URL/Filename readability. https://github.com/rails/rails/blob/92703a9ea5d8b96f30e0b706b801c9185ef14f0e/activesupport/lib/active_support/inflector/transliterate.rb#L90
This would be helpful for me, but if it's not what you are going for here, no worries! I'd be happy to change this to an optional behavior with another function parameter or something.
Thanks!