### PR TITLE
Adds fix for singularizing Menu

### DIFF
--- a/lib/inflex/pluralize.ex
+++ b/lib/inflex/pluralize.ex
@@ -23,7 +23,7 @@ defmodule Inflex.Pluralize do
     { ~r/^(zombie)s$/i, "\\1" },
     { ~r/(g)eese/i, "\\1oose" },
     { ~r/(criteri)a/i, "\\1on" },
-    { ~r/^(m)en/i, "\\1an"},
+    { ~r/^(m)en$/i, "\\1an"},
     { ~r/^(echo)es/i, "\\1"},
     { ~r/^(hero)es/i, "\\1"},
     { ~r/^(potato)es/i, "\\1"},

--- a/test/inflex_test.exs
+++ b/test/inflex_test.exs
@@ -4,6 +4,7 @@ defmodule InflexTest do
   import Inflex
 
   test :singularize do
+    assert "Menu" == singularize("Menus")
     assert "addendum" == singularize("addenda")
     assert "alga" == singularize("algae")
     assert "alumnus" == singularize("alumni")


### PR DESCRIPTION
Discovered that the `singularize` function would return `Manu` when passed any iteration of `Menu` in an attempt  to singularize Men to Man. Added a end of line match to avoid a string like `Menu` from triggering that rule.

Cheers!