### PR TITLE
Adds fix for pluralizing `aircraft`

### DIFF
--- a/lib/inflex/pluralize.ex
+++ b/lib/inflex/pluralize.ex
@@ -3,6 +3,7 @@ defmodule Inflex.Pluralize do
   @default true
 
   @uncountable  [
+    "aircraft",
     "equipment",
     "fish",
     "information",

--- a/test/inflex_test.exs
+++ b/test/inflex_test.exs
@@ -134,6 +134,7 @@ defmodule InflexTest do
   end
 
   test :skip_pluralize do
+    assert "aircraft" == pluralize("aircraft")
     assert "dogs" == pluralize("dogs")
   end
 


### PR DESCRIPTION
https://www.merriam-webster.com/dictionary/aircraft