### PR TITLE
Adds fix for pluralizing `deer`

### DIFF
--- a/lib/inflex/pluralize.ex
+++ b/lib/inflex/pluralize.ex
@@ -3,6 +3,7 @@ defmodule Inflex.Pluralize do
   @default true
 
   @uncountable  [
+    "deer",
     "equipment",
     "fish",
     "information",

--- a/test/inflex_test.exs
+++ b/test/inflex_test.exs
@@ -134,6 +134,7 @@ defmodule InflexTest do
   end
 
   test :skip_pluralize do
+    assert "deer" == pluralize("deer")
     assert "dogs" == pluralize("dogs")
   end
 


### PR DESCRIPTION
Addresses PR #57 
http://grammarist.com/plurals/deer-vs-deers/