### PR TITLE
Ordinalize fixes

### DIFF
--- a/lib/inflex/ordinalize.ex
+++ b/lib/inflex/ordinalize.ex
@@ -3,7 +3,7 @@ defmodule Inflex.Ordinalize do
 
   def ordinalize(number) when is_number(number) do
     cond do
-      number in [11, 12, 13] ->
+      rem(number, 100) in 11..13 ->
         Integer.to_string(number) <> "th"
       rem(number, 10) == 1 ->
         Integer.to_string(number) <> "st"

--- a/lib/inflex/ordinalize.ex
+++ b/lib/inflex/ordinalize.ex
@@ -2,14 +2,16 @@ defmodule Inflex.Ordinalize do
   @moduledoc false
 
   def ordinalize(number) when is_number(number) do
+    abs_number = abs(number)
+
     cond do
-      rem(number, 100) in 11..13 ->
+      rem(abs_number, 100) in 11..13 ->
         Integer.to_string(number) <> "th"
-      rem(number, 10) == 1 ->
+      rem(abs_number, 10) == 1 ->
         Integer.to_string(number) <> "st"
-      rem(number, 10) == 2 ->
+      rem(abs_number, 10) == 2 ->
         Integer.to_string(number) <> "nd"
-      rem(number, 10) == 3 ->
+      rem(abs_number, 10) == 3 ->
         Integer.to_string(number) <> "rd"
       true ->
         Integer.to_string(number) <> "th"

--- a/test/inflex_test.exs
+++ b/test/inflex_test.exs
@@ -192,6 +192,9 @@ defmodule InflexTest do
     assert "85th" == ordinalize(85)
     assert "90th" == ordinalize(90)
     assert "92nd" == ordinalize(92)
+    assert "111th" == ordinalize(111)
+    assert "112th" == ordinalize(112)
+    assert "113th" == ordinalize(113)
   end
 
   test :inflect do

--- a/test/inflex_test.exs
+++ b/test/inflex_test.exs
@@ -169,6 +169,12 @@ defmodule InflexTest do
   end
 
   test :ordinalize do
+    assert "-113th" == ordinalize(-113)
+    assert "-112th" == ordinalize(-112)
+    assert "-111th" == ordinalize(-111)
+    assert "-3rd" == ordinalize(-3)
+    assert "-2nd" == ordinalize(-2)
+    assert "-1st" == ordinalize(-1)
     assert "1st" == ordinalize(1)
     assert "2nd" == ordinalize(2)
     assert "3rd" == ordinalize(3)


### PR DESCRIPTION
This PR updates `Inflex.Ordinalize` to correctly handle 111, 112, 113 as well as negative numbers
