### PR TITLE
Fix camelize lower

### DIFF
--- a/lib/inflex/camelize.ex
+++ b/lib/inflex/camelize.ex
@@ -3,8 +3,9 @@ defmodule Inflex.Camelize do
 
   def camelize(word, option\\:upper) do
     case Regex.split(~r/(?:^|[-_])|(?=[A-Z])/, to_string(word)) do
-      words -> words |> camelize_list(option)
-                     |> Enum.join
+      words ->
+        words |> Enum.filter(&(&1 != "")) |> camelize_list(option)
+        |> Enum.join()
     end
   end
 


### PR DESCRIPTION
camelize :lower does not work anymore in Elixir 1.6.0. The Regex.split function returns an empty string as the first element of the list in some cases. This leads to the wrong behaviour. This is a quick fix, simply eliminating these leading empty strings.