### PR TITLE
Fix singularize for nouns with endings of `erve`

### DIFF
--- a/lib/inflex/pluralize.ex
+++ b/lib/inflex/pluralize.ex
@@ -86,6 +86,7 @@ defmodule Inflex.Pluralize do
     { ~r/(octop|vir)i$/i, "\\1us" },
     { ~r/(hive)s$/i, "\\1" },
     { ~r/(tive)s$/i, '\\1' },
+    { ~r/(er)ves$/i, "\\1ve" },
     { ~r/([lora])ves$/i, "\\1f" },
     { ~r/([^f])ves$/i, "\\1fe" },
     { ~r/([^aeiouy]|qu)ies$/i, "\\1y" },

--- a/test/inflex_test.exs
+++ b/test/inflex_test.exs
@@ -55,6 +55,8 @@ defmodule InflexTest do
     assert "license" == singularize("licenses")
 
     assert "bus" == singularize(:buses)
+    assert "reserve" == singularize("reserves")
+    assert "nerve" == singularize("nerves")
   end
 
   test :pluralize do
@@ -106,6 +108,8 @@ defmodule InflexTest do
     assert "phenomena" == pluralize("phenomenon")
 
     assert "buses" == pluralize(:bus)
+    assert "reserves" == pluralize("reserve")
+    assert "nerves" == pluralize("nerve")
   end
 
   test :special_case_nouns_ending_in_f_or_fe do


### PR DESCRIPTION
Hi, this is a small fix for this issue: #70 