### PR TITLE
fix pull request reversion for *tives

### DIFF
--- a/lib/inflex/pluralize.ex
+++ b/lib/inflex/pluralize.ex
@@ -85,7 +85,7 @@ defmodule Inflex.Pluralize do
     { ~r/(analy)(sis|ses)$/i, "\\1sis" },
     { ~r/(octop|vir)i$/i, "\\1us" },
     { ~r/(hive)s$/i, "\\1" },
-    { ~r/(tive)s$/i, '\\1' },
+    { ~r/(tive)s$/i, "\\1" },
     { ~r/(er)ves$/i, "\\1ve" },
     { ~r/([lora])ves$/i, "\\1f" },
     { ~r/([^f])ves$/i, "\\1fe" },

--- a/test/inflex_test.exs
+++ b/test/inflex_test.exs
@@ -57,6 +57,7 @@ defmodule InflexTest do
     assert "bus" == singularize(:buses)
     assert "reserve" == singularize("reserves")
     assert "nerve" == singularize("nerves")
+    assert "representative" == singularize("representatives")
   end
 
   test :pluralize do


### PR DESCRIPTION
The fix for *tives in https://github.com/nurugger07/inflex/pull/69 was reverted in https://github.com/nurugger07/inflex/pull/71

This PR fixes that and adds a test. I'm not sure how the examples are being ordered, so I just added it to the end. 