### PR TITLE
add recommended Elixir and Erlang/OTP combinations to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,14 +8,14 @@ otp_release:
 matrix:
   include:
     - elixir: 1.6.6
-      otp_release: 19.3.6.13
+      otp_release: 19.3
     - elixir: 1.7.4
-      otp_release: 19.3.6.13
+      otp_release: 19.3
     - elixir: 1.8.2
-      otp_release: 20.3.8.26
+      otp_release: 20.3.8.22
     - elixir: 1.9.4
-      otp_release: 20.3.8.26
+      otp_release: 20.3.8.22
     - elixir: 1.10.4
-      otp_release: 21.3.8.17
+      otp_release: 21.3.8.1
     - elixir: 1.10.4
       otp_release: 23.0.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,9 @@ otp_release:
 matrix:
   include:
     - elixir: 1.6.6
-      otp_release: 19.3
+      otp_release: 20.3.8.22
     - elixir: 1.7.4
-      otp_release: 19.3
+      otp_release: 20.3.8.22
     - elixir: 1.8.2
       otp_release: 20.3.8.22
     - elixir: 1.9.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,21 @@
 sudo: false
 language: elixir
 elixir:
-  - 1.8.1
+  - 1.10.4
 otp_release:
-  - 21.3.1
+  - 22.3.4.10
 
 matrix:
   include:
     - elixir: 1.6.6
-      otp_release: 21.3.1
-    - elixir: 1.7.3
-      otp_release: 21.3.1
+      otp_release: 19.3.6.13
+    - elixir: 1.7.4
+      otp_release: 19.3.6.13
+    - elixir: 1.8.2
+      otp_release: 20.3.8.26
+    - elixir: 1.9.4
+      otp_release: 20.3.8.26
+    - elixir: 1.10.4
+      otp_release: 21.3.8.17
+    - elixir: 1.10.4
+      otp_release: 23.0.3


### PR DESCRIPTION
This pull request makes sure all recommended Elixir and Erlang/OTP combinations are run on CI.

Quoting José Valim:
> I would still advise folks to go with:
> * For each Elixir version, add a run with earliest supported Erlang/OTP
> * For the last Elixir version, also test the latest supported Erlang/OTP

Please refer to the original discussion on https://github.com/dashbitco/broadway/pull/188 for the full rationale.