### PR TITLE
add "Inflex requires Erlang/OTP 20+" info to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,11 @@ If you are not using [hex](http://hex.pm) you can add the dependency using the g
 
 Then run `mix deps.get` in the shell to fetch and compile the dependencies.
 
+### Requirements
+
+Although Inflex supports Elixir 1.6, which is [compatible](https://hexdocs.pm/elixir/compatibility-and-deprecations.html#compatibility-between-elixir-and-erlang-otp) with Erlang/OTP 19–20, [Inflex requires Erlang/OTP 20+](https://github.com/nurugger07/inflex/blob/master/lib/inflex/parameterize.ex#L21).
+
+
 To incorporate Inflex in your modules, use `import`.
 
 ``` elixir


### PR DESCRIPTION
Add Erlang/OTP 20+ requirement to README to prevent [`warning: function :unicode.characters_to_nfd_binary/1 is undefined or private.` and broken behaviour, including failing tests, when such requirement is not met, as shown by the following evidence:
- https://travis-ci.org/github/nurugger07/inflex/jobs/722512173
- https://travis-ci.org/github/nurugger07/inflex/jobs/722512174

The referred `characters_to_nfd_binary` function was added on OTP 20, as indicated in the upper right corner:
![image](https://user-images.githubusercontent.com/456804/91667106-80070280-ead8-11ea-9765-3c8ae0b0e83a.png)
Source: https://erlang.org/doc/man/unicode.htm