### PR TITLE
Inflect - singularize word for n = 1.0

### DIFF
--- a/lib/inflex/pluralize.ex
+++ b/lib/inflex/pluralize.ex
@@ -187,7 +187,7 @@ defmodule Inflex.Pluralize do
 
   def pluralize(word), do: find_match(@plural, word)
 
-  def inflect(word, 1), do: singularize(word)
+  def inflect(word, n) when n == 1, do: singularize(word)
   def inflect(word, n) when is_number(n), do: pluralize(word)
 
   defp find_match(set, word) do

--- a/test/inflex_test.exs
+++ b/test/inflex_test.exs
@@ -266,11 +266,14 @@ defmodule InflexTest do
 
   test :inflect do
     assert "child" == inflect("children", 1)
+    assert "child" == inflect("children", 1.0)
     assert "people" == inflect("person", 2)
     assert "People" == inflect("Person", 2)
     assert "dogs" == inflect("dog", 3.2)
     assert "slice" == inflect("slice", 1)
+    assert "slice" == inflect("slice", 1.0)
     assert "accomplice" == inflect("accomplice", 1)
+    assert "accomplice" == inflect("accomplice", 1.0)
   end
 
 end


### PR DESCRIPTION
Currently `Inflex.inflect("word", 1.0)` outputs `"words"`. This adjusts `inflect/2` to singularize for any float or int == to 1.